### PR TITLE
SAK-40007 - corrected table name

### DIFF
--- a/docs/conversion/sakai_12_mysql_conversion.sql
+++ b/docs/conversion/sakai_12_mysql_conversion.sql
@@ -379,7 +379,7 @@ set @exist_Check := (
     and COLUMN_NAME='allowlori' 
     and TABLE_SCHEMA=database()
 ) ;
-set @sqlstmt := if(@exist_Check>0,'alter table lti_tools drop column allowlori', 'select ''''') ;
+set @sqlstmt := if(@exist_Check>0,'alter table lti_deploy drop column allowlori', 'select ''''') ;
 prepare stmt from @sqlstmt ;
 execute stmt;
 


### PR DESCRIPTION
To quote the Jira:

>  it seems like someone copy&pasted a statement and didn't update the table name, i.e. the script tries to drop that column twice from the table "lti_tools" instead of once from "lti_tools" and once from "lti_deploy".


Looking at the oracle script confirms that:

> -- SAK-32442 - LTI Column cleanup
-- These conversions may fail if you started Sakai at newer versions that didn't contain these columns/tables
alter table lti_tools drop column enabled_capability;
alter table lti_deploy drop column allowlori;
alter table lti_tools drop column allowlori;
