### PR TITLE
SAK-44637 - Set pl_lessonsselection to 1

### DIFF
--- a/docs/conversion/sakai_21_mysql_conversion.sql
+++ b/docs/conversion/sakai_21_mysql_conversion.sql
@@ -12,3 +12,10 @@ ALTER TABLE MFR_PRIVATE_FORUM_T MODIFY COLUMN AUTO_FORWARD INT NOT NULL DEFAULT 
 ALTER TABLE rbc_rubric ADD COLUMN WEIGHTED bit(1) NOT NULL DEFAULT 0;
 ALTER TABLE rbc_criterion ADD COLUMN WEIGHT DOUBLE NULL DEFAULT 0;
 
+-- SAK-44637 - Make the Lessons Placement checkbox work
+-- Note that SAK-44636 already added the column in sakai_20_1-20_2_mysql_conversion.sql
+-- It is included here and commented out in case you need it.
+-- ALTER TABLE lti_tools ADD pl_lessonsselection TINYINT DEFAULT 0;
+-- Existing records needed to be switched on right before the feature is used
+UPDATE lti_tools SET pl_lessonsselection = 1;
+-- END SAK-44637


### PR DESCRIPTION
Turn on the pl_lessonsselection for all existing records (including those after the Sakai 20) conversion has run.  When SAK-44637 lands in the code base, all of the tools will vanish from the Lessons drop-down unless this is run.  If the tools vanish - just run this update later.

Please help with Oracle.