### PR TITLE
 Samigo: show correction to student - conversion script addition

### DIFF
--- a/docs/conversion/s2u_features/S2U-23-mysql.sql
+++ b/docs/conversion/s2u_features/S2U-23-mysql.sql
@@ -1,4 +1,7 @@
 -- S2U-23 --
 ALTER TABLE SAM_PUBLISHEDFEEDBACK_T ADD SHOWCORRECTION bit(1) DEFAULT b'0' NOT NULL;
 ALTER TABLE SAM_ASSESSFEEDBACK_T ADD SHOWCORRECTION bit(1) DEFAULT b'0' NOT NULL;
+-- to preserve the complete functionality on assessments previous to the patch with 'showcorrectresponse' enabled
+UPDATE SAM_PUBLISHEDFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
+UPDATE SAM_ASSESSFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
 -- END S2U-23 --

--- a/docs/conversion/s2u_features/S2U-23-oracle.sql
+++ b/docs/conversion/s2u_features/S2U-23-oracle.sql
@@ -1,4 +1,7 @@
 -- S2U-27 --
 ALTER TABLE SAM_PUBLISHEDFEEDBACK_T ADD SHOWCORRECTION NUMBER(1,0) DEFAULT 0 NOT NULL;
 ALTER TABLE SAM_ASSESSFEEDBACK_T ADD SHOWCORRECTION NUMBER(1,0) DEFAULT 0 NOT NULL;
+-- to preserve the complete functionality on assessments previous to the patch with 'showcorrectresponse' enabled
+UPDATE SAM_PUBLISHEDFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
+UPDATE SAM_ASSESSFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
 -- END S2U-27 --

--- a/docs/conversion/sakai_25_mysql_conversion.sql
+++ b/docs/conversion/sakai_25_mysql_conversion.sql
@@ -72,6 +72,9 @@ CREATE TABLE rwikipagegroups (
 -- S2U-23 --
 ALTER TABLE SAM_PUBLISHEDFEEDBACK_T ADD SHOWCORRECTION bit(1) DEFAULT b'0' NOT NULL;
 ALTER TABLE SAM_ASSESSFEEDBACK_T ADD SHOWCORRECTION bit(1) DEFAULT b'0' NOT NULL;
+-- to preserve the complete functionality on assessments previous to the patch with 'showcorrectresponse' enabled
+UPDATE SAM_PUBLISHEDFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
+UPDATE SAM_ASSESSFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
 -- END S2U-23 --
 
 -- S2U-29 --

--- a/docs/conversion/sakai_25_oracle_conversion.sql
+++ b/docs/conversion/sakai_25_oracle_conversion.sql
@@ -49,6 +49,9 @@ CREATE TABLE rwikipagegroups (
 -- S2U-23 --
 ALTER TABLE SAM_PUBLISHEDFEEDBACK_T ADD SHOWCORRECTION NUMBER(1,0) DEFAULT 0 NOT NULL;
 ALTER TABLE SAM_ASSESSFEEDBACK_T ADD SHOWCORRECTION NUMBER(1,0) DEFAULT 0 NOT NULL;
+-- to preserve the complete functionality on assessments previous to the patch with 'showcorrectresponse' enabled
+UPDATE SAM_PUBLISHEDFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
+UPDATE SAM_ASSESSFEEDBACK_T SET showcorrection = 1 WHERE showcorrection = 0 AND showcorrectresponse = 1;
 -- END S2U-23 --
 
 -- S2U-29 --


### PR DESCRIPTION
S2U-23 (https://github.com/sakaiproject/sakai/pull/12023) divided an existing feature into two different checkboxes.
Assessments previous to the patch that had the original option enabled would miss part of the feature, as the new option/checkbox isn't enabled by default.

That's what this script tries to avoid, by enabling 'showcorrection' if 'showcorrectresponse' was _true_.