### PR TITLE
SAK-52039 Polls db evolution/migration

### DIFF
--- a/docs/conversion/sakai_26_mysql_conversion.sql
+++ b/docs/conversion/sakai_26_mysql_conversion.sql
@@ -103,6 +103,14 @@ BEGIN
         ALTER TABLE POLL_OPTION DROP COLUMN OPTION_UUID;
         CREATE INDEX POLLTOOL_OPTION_POLLID_IDX ON POLL_OPTION (OPTION_POLL_ID);
 
+        -- The JPA entity manages OPTION_ORDER via @OrderColumn on a bidirectional
+        -- (mappedBy) Poll.options collection. Hibernate inserts a new Option row
+        -- before it knows the collection's final order, then issues a follow-up
+        -- UPDATE to set OPTION_ORDER once the index is known. Without a default,
+        -- that first INSERT fails outright ("Field 'OPTION_ORDER' doesn't have a
+        -- default value") as soon as a poll option is added through the new tool.
+        ALTER TABLE POLL_OPTION MODIFY COLUMN OPTION_ORDER INT NOT NULL DEFAULT 0;
+
         -- --- POLL_VOTE: votes reach a poll through their option now ---
         -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
         DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL;

--- a/docs/conversion/sakai_26_mysql_conversion.sql
+++ b/docs/conversion/sakai_26_mysql_conversion.sql
@@ -72,6 +72,25 @@ BEGIN
           AND COLUMN_NAME  = 'POLL_UUID'
     ) THEN
 
+        -- Self-heal malformed/duplicate POLL_UUID values before this
+        -- procedure promotes the column to the primary key. Real-world
+        -- instances have been found with POLL_UUID = NULL, the literal
+        -- string 'null' (residue of a historic bulk import), or values
+        -- shared by more than one poll. Left unrepaired, the destructive
+        -- ALTER/DELETE statements below are not transactional, so a bad
+        -- value causes the final "CHANGE COLUMN ... NOT NULL" to fail and
+        -- leaves the schema half-migrated (POLL_ID already dropped, new PK
+        -- never added, options silently deleted as orphaned).
+        UPDATE POLL_POLL SET POLL_UUID = UUID()
+        WHERE POLL_UUID IS NULL
+           OR LENGTH(POLL_UUID) <> 36
+           OR POLL_UUID IN (
+                SELECT dup.POLL_UUID FROM (
+                    SELECT POLL_UUID FROM POLL_POLL
+                    GROUP BY POLL_UUID HAVING COUNT(*) > 1
+                ) dup
+           );
+
         -- --- POLL_OPTION: re-point OPTION_POLL_ID from numeric poll id to poll UUID ---
         ALTER TABLE POLL_OPTION ADD COLUMN OPTION_POLL_ID_TMP VARCHAR(36);
         UPDATE POLL_OPTION o

--- a/docs/conversion/sakai_26_mysql_conversion.sql
+++ b/docs/conversion/sakai_26_mysql_conversion.sql
@@ -46,3 +46,67 @@ CREATE TABLE mc_team_archive (
 
 ALTER TABLE mc_team_archive ADD CONSTRAINT UKmc9f2k3lrxwp7v8qntjd5hs0ya UNIQUE (site_id, team_id);
 -- END SAK-52642
+
+-- SAK-52039 Polls: migrate persistence to Spring Data JPA (MySQL)
+
+-- The Poll primary key changes from a numeric, AUTO_INCREMENT POLL_ID to the
+-- 36-char UUID that was previously stored in POLL_UUID. The Option/Vote
+-- foreign keys are re-pointed to the new string key, POLL_VOTE.VOTE_POLL_ID
+-- is dropped (votes now reach a poll through their option), VOTE_OPTION
+-- becomes NOT NULL, and the obsolete OPTION_UUID/POLL_UUID columns are
+-- removed. Several user/site/ip columns are narrowed to VARCHAR(99) to match
+-- the JPA entities.
+
+-- Run once when upgrading an existing instance. The whole migration is
+-- guarded on the presence of POLL_POLL.POLL_UUID, so it is a no-op on schemas
+-- that Hibernate already created in the new shape and is safe to re-run.
+
+DROP PROCEDURE IF EXISTS polls_migrate_jpa;
+DELIMITER //
+CREATE PROCEDURE polls_migrate_jpa()
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME   = 'POLL_POLL'
+          AND COLUMN_NAME  = 'POLL_UUID'
+    ) THEN
+
+        -- --- POLL_OPTION: re-point OPTION_POLL_ID from numeric poll id to poll UUID ---
+        ALTER TABLE POLL_OPTION ADD COLUMN OPTION_POLL_ID_TMP VARCHAR(36);
+        UPDATE POLL_OPTION o
+            JOIN POLL_POLL p ON o.OPTION_POLL_ID = p.POLL_ID
+            SET o.OPTION_POLL_ID_TMP = p.POLL_UUID;
+        -- Drop options orphaned from any poll; they can no longer be mapped.
+        DELETE FROM POLL_OPTION WHERE OPTION_POLL_ID_TMP IS NULL;
+        ALTER TABLE POLL_OPTION DROP COLUMN OPTION_POLL_ID;
+        ALTER TABLE POLL_OPTION CHANGE COLUMN OPTION_POLL_ID_TMP OPTION_POLL_ID VARCHAR(36) NOT NULL;
+        ALTER TABLE POLL_OPTION DROP COLUMN OPTION_UUID;
+        CREATE INDEX POLLTOOL_OPTION_POLLID_IDX ON POLL_OPTION (OPTION_POLL_ID);
+
+        -- --- POLL_VOTE: votes reach a poll through their option now ---
+        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
+        DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL;
+        ALTER TABLE POLL_VOTE DROP COLUMN VOTE_POLL_ID;
+        ALTER TABLE POLL_VOTE MODIFY COLUMN VOTE_OPTION BIGINT NOT NULL;
+        ALTER TABLE POLL_VOTE MODIFY COLUMN USER_ID VARCHAR(99) NOT NULL;
+        ALTER TABLE POLL_VOTE MODIFY COLUMN VOTE_IP VARCHAR(99) NOT NULL;
+        ALTER TABLE POLL_VOTE MODIFY COLUMN VOTE_SUBMISSION_ID VARCHAR(99) NOT NULL;
+        CREATE INDEX POLLTOOL_VOTE_OPTION_IDX ON POLL_VOTE (VOTE_OPTION);
+
+        -- --- POLL_POLL: promote POLL_UUID to the primary key ---
+        ALTER TABLE POLL_POLL MODIFY COLUMN POLL_ID BIGINT NOT NULL;  -- drop AUTO_INCREMENT
+        ALTER TABLE POLL_POLL DROP PRIMARY KEY;
+        ALTER TABLE POLL_POLL DROP COLUMN POLL_ID;
+        ALTER TABLE POLL_POLL CHANGE COLUMN POLL_UUID POLL_ID VARCHAR(36) NOT NULL;
+        ALTER TABLE POLL_POLL ADD PRIMARY KEY (POLL_ID);
+        ALTER TABLE POLL_POLL MODIFY COLUMN POLL_OWNER VARCHAR(99) NOT NULL;
+        ALTER TABLE POLL_POLL MODIFY COLUMN POLL_SITE_ID VARCHAR(99) NOT NULL;
+        ALTER TABLE POLL_POLL MODIFY COLUMN POLL_DISPLAY_RESULT VARCHAR(99) NOT NULL;
+
+    END IF;
+END //
+DELIMITER ;
+CALL polls_migrate_jpa();
+DROP PROCEDURE IF EXISTS polls_migrate_jpa;
+-- END SAK-52039

--- a/docs/conversion/sakai_26_oracle_conversion.sql
+++ b/docs/conversion/sakai_26_oracle_conversion.sql
@@ -82,6 +82,30 @@ BEGIN
 
     IF v_count > 0 THEN
 
+        -- Self-heal malformed/duplicate POLL_UUID values before this
+        -- block promotes the column to the primary key. Real-world
+        -- instances have been found with POLL_UUID = NULL, the literal
+        -- string 'null' (residue of a historic bulk import), or values
+        -- shared by more than one poll. Left unrepaired, the destructive
+        -- ALTER/DELETE statements below are not transactional, so a bad
+        -- value causes a later MODIFY/ADD PRIMARY KEY to fail and leaves
+        -- the schema half-migrated (POLL_ID already dropped, new PK never
+        -- added, options silently deleted as orphaned).
+        -- SYS_GUID() is formatted to a 36-char hyphenated UUID to match
+        -- the Java/MySQL UUID() shape expected by the rest of this migration.
+        UPDATE POLL_POLL
+        SET POLL_UUID = LOWER(REGEXP_REPLACE(RAWTOHEX(SYS_GUID()),
+                '([A-F0-9]{8})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{12})',
+                '\1-\2-\3-\4-\5'))
+        WHERE POLL_UUID IS NULL
+           OR LENGTH(POLL_UUID) <> 36
+           OR POLL_UUID IN (
+                SELECT dup.POLL_UUID FROM (
+                    SELECT POLL_UUID FROM POLL_POLL
+                    GROUP BY POLL_UUID HAVING COUNT(*) > 1
+                ) dup
+           );
+
         -- --- POLL_OPTION: re-point OPTION_POLL_ID from numeric poll id to poll UUID ---
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION ADD OPTION_POLL_ID_TMP VARCHAR2(36)';
         EXECUTE IMMEDIATE 'UPDATE POLL_OPTION o SET o.OPTION_POLL_ID_TMP = ' ||

--- a/docs/conversion/sakai_26_oracle_conversion.sql
+++ b/docs/conversion/sakai_26_oracle_conversion.sql
@@ -120,6 +120,14 @@ BEGIN
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION DROP COLUMN OPTION_UUID';
         EXECUTE IMMEDIATE 'CREATE INDEX POLLTOOL_OPTION_POLLID_IDX ON POLL_OPTION (OPTION_POLL_ID)';
 
+        -- The JPA entity manages OPTION_ORDER via @OrderColumn on a bidirectional
+        -- (mappedBy) Poll.options collection. Hibernate inserts a new Option row
+        -- before it knows the collection's final order, then issues a follow-up
+        -- UPDATE to set OPTION_ORDER once the index is known. Without a default,
+        -- that first INSERT fails as soon as a poll option is added through the
+        -- new tool (same failure mode as MySQL's missing-default error).
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION MODIFY (OPTION_ORDER NUMBER(10,0) DEFAULT 0 NOT NULL)';
+
         -- --- POLL_VOTE: votes reach a poll through their option now ---
         -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
         EXECUTE IMMEDIATE 'DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL';

--- a/docs/conversion/sakai_26_oracle_conversion.sql
+++ b/docs/conversion/sakai_26_oracle_conversion.sql
@@ -56,3 +56,73 @@ CREATE TABLE mc_team_archive (
   CONSTRAINT UKmc_ta UNIQUE (site_id, team_id)
 );
 -- END SAK-52642
+
+-- SAK-52039 Polls: migrate persistence to Spring Data JPA (Oracle)
+
+-- The Poll primary key changes from a numeric POLL_ID (fed by the
+-- POLL_POLL_ID_SEQ sequence) to the 36-char UUID that was previously stored
+-- in POLL_UUID. The Option/Vote foreign keys are re-pointed to the new string
+-- key, POLL_VOTE.VOTE_POLL_ID is dropped (votes now reach a poll through their
+-- option), VOTE_OPTION becomes NOT NULL, and the obsolete OPTION_UUID/POLL_UUID
+-- columns are removed. Several user/site/ip columns are narrowed to
+-- VARCHAR2(99) to match the JPA entities.
+
+-- Run once when upgrading an existing instance. The whole migration is guarded
+-- on the presence of POLL_POLL.POLL_UUID, so it is a no-op on schemas that
+-- Hibernate already created in the new shape and is safe to re-run.
+-- =====================================================================
+
+DECLARE
+    v_count NUMBER;
+BEGIN
+    SELECT COUNT(*) INTO v_count
+    FROM   USER_TAB_COLUMNS
+    WHERE  TABLE_NAME  = 'POLL_POLL'
+      AND  COLUMN_NAME = 'POLL_UUID';
+
+    IF v_count > 0 THEN
+
+        -- --- POLL_OPTION: re-point OPTION_POLL_ID from numeric poll id to poll UUID ---
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION ADD OPTION_POLL_ID_TMP VARCHAR2(36)';
+        EXECUTE IMMEDIATE 'UPDATE POLL_OPTION o SET o.OPTION_POLL_ID_TMP = ' ||
+                          '(SELECT p.POLL_UUID FROM POLL_POLL p WHERE p.POLL_ID = o.OPTION_POLL_ID)';
+        -- Drop options orphaned from any poll; they can no longer be mapped.
+        EXECUTE IMMEDIATE 'DELETE FROM POLL_OPTION WHERE OPTION_POLL_ID_TMP IS NULL';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION DROP COLUMN OPTION_POLL_ID';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION RENAME COLUMN OPTION_POLL_ID_TMP TO OPTION_POLL_ID';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION MODIFY (OPTION_POLL_ID VARCHAR2(36) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION DROP COLUMN OPTION_UUID';
+        EXECUTE IMMEDIATE 'CREATE INDEX POLLTOOL_OPTION_POLLID_IDX ON POLL_OPTION (OPTION_POLL_ID)';
+
+        -- --- POLL_VOTE: votes reach a poll through their option now ---
+        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
+        EXECUTE IMMEDIATE 'DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE DROP COLUMN VOTE_POLL_ID';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (VOTE_OPTION NUMBER(19,0) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (USER_ID VARCHAR2(99) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (VOTE_IP VARCHAR2(99) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (VOTE_SUBMISSION_ID VARCHAR2(99) NOT NULL)';
+        EXECUTE IMMEDIATE 'CREATE INDEX POLLTOOL_VOTE_OPTION_IDX ON POLL_VOTE (VOTE_OPTION)';
+
+        -- --- POLL_POLL: promote POLL_UUID to the primary key ---
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL DROP PRIMARY KEY';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL DROP COLUMN POLL_ID';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL RENAME COLUMN POLL_UUID TO POLL_ID';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL MODIFY (POLL_ID VARCHAR2(36) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL ADD CONSTRAINT POLL_POLL_PK PRIMARY KEY (POLL_ID)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL MODIFY (POLL_OWNER VARCHAR2(99) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL MODIFY (POLL_SITE_ID VARCHAR2(99) NOT NULL)';
+        EXECUTE IMMEDIATE 'ALTER TABLE POLL_POLL MODIFY (POLL_DISPLAY_RESULT VARCHAR2(99) NOT NULL)';
+
+    END IF;
+END;
+/
+
+-- The poll primary key is no longer sequence-generated; drop the obsolete sequence.
+BEGIN
+    EXECUTE IMMEDIATE 'DROP SEQUENCE POLL_POLL_ID_SEQ';
+EXCEPTION WHEN OTHERS THEN NULL;
+END;
+/
+-- END SAK-52039
+

--- a/docs/conversion/sakai_26_oracle_conversion.sql
+++ b/docs/conversion/sakai_26_oracle_conversion.sql
@@ -93,18 +93,20 @@ BEGIN
         -- added, options silently deleted as orphaned).
         -- SYS_GUID() is formatted to a 36-char hyphenated UUID to match
         -- the Java/MySQL UUID() shape expected by the rest of this migration.
-        UPDATE POLL_POLL
-        SET POLL_UUID = LOWER(REGEXP_REPLACE(RAWTOHEX(SYS_GUID()),
-                '([A-F0-9]{8})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{12})',
-                '\1-\2-\3-\4-\5'))
-        WHERE POLL_UUID IS NULL
-           OR LENGTH(POLL_UUID) <> 36
-           OR POLL_UUID IN (
-                SELECT dup.POLL_UUID FROM (
-                    SELECT POLL_UUID FROM POLL_POLL
-                    GROUP BY POLL_UUID HAVING COUNT(*) > 1
-                ) dup
-           );
+        EXECUTE IMMEDIATE q'[
+            UPDATE POLL_POLL
+            SET POLL_UUID = LOWER(REGEXP_REPLACE(RAWTOHEX(SYS_GUID()),
+                    '([A-F0-9]{8})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{4})([A-F0-9]{12})',
+                    '\1-\2-\3-\4-\5'))
+            WHERE POLL_UUID IS NULL
+               OR LENGTH(POLL_UUID) <> 36
+               OR POLL_UUID IN (
+                    SELECT dup.POLL_UUID FROM (
+                        SELECT POLL_UUID FROM POLL_POLL
+                        GROUP BY POLL_UUID HAVING COUNT(*) > 1
+                    ) dup
+               )
+        ]';
 
         -- --- POLL_OPTION: re-point OPTION_POLL_ID from numeric poll id to poll UUID ---
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION ADD OPTION_POLL_ID_TMP VARCHAR2(36)';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added MySQL and Oracle migration scripts for the version 26 upgrade.
  * Updated polling data storage to use UUID-based identifiers while preserving existing poll, option, and vote relationships.
  * Improved migration safety by repairing invalid or duplicate identifiers, removing orphaned records, and adding required constraints and indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->