### PR TITLE
SAK-52811 Polls: delete votes orphaned by option cleanup during JPA migration

### DIFF
--- a/docs/conversion/sakai_26_mysql_conversion.sql
+++ b/docs/conversion/sakai_26_mysql_conversion.sql
@@ -112,8 +112,14 @@ BEGIN
         ALTER TABLE POLL_OPTION MODIFY COLUMN OPTION_ORDER INT NOT NULL DEFAULT 0;
 
         -- --- POLL_VOTE: votes reach a poll through their option now ---
-        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
-        DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL;
+        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one,
+        -- plus votes that still point at an OPTION_ID just deleted above as
+        -- orphaned (poll with an unresolvable POLL_UUID). Without the second
+        -- half of this condition those votes survive the migration as
+        -- orphans referencing a non-existent option.
+        DELETE FROM POLL_VOTE
+        WHERE VOTE_OPTION IS NULL
+           OR VOTE_OPTION NOT IN (SELECT OPTION_ID FROM POLL_OPTION);
         ALTER TABLE POLL_VOTE DROP COLUMN VOTE_POLL_ID;
         ALTER TABLE POLL_VOTE MODIFY COLUMN VOTE_OPTION BIGINT NOT NULL;
         ALTER TABLE POLL_VOTE MODIFY COLUMN USER_ID VARCHAR(99) NOT NULL;

--- a/docs/conversion/sakai_26_oracle_conversion.sql
+++ b/docs/conversion/sakai_26_oracle_conversion.sql
@@ -129,8 +129,14 @@ BEGIN
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_OPTION MODIFY (OPTION_ORDER NUMBER(10,0) DEFAULT 0 NOT NULL)';
 
         -- --- POLL_VOTE: votes reach a poll through their option now ---
-        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one.
-        EXECUTE IMMEDIATE 'DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL';
+        -- VOTE_OPTION becomes NOT NULL, so drop votes that never recorded one,
+        -- plus votes that still point at an OPTION_ID just deleted above as
+        -- orphaned (poll with an unresolvable POLL_UUID). Without the second
+        -- half of this condition those votes survive the migration as
+        -- orphans referencing a non-existent option.
+        EXECUTE IMMEDIATE 'DELETE FROM POLL_VOTE
+            WHERE VOTE_OPTION IS NULL
+               OR VOTE_OPTION NOT IN (SELECT OPTION_ID FROM POLL_OPTION)';
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE DROP COLUMN VOTE_POLL_ID';
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (VOTE_OPTION NUMBER(19,0) NOT NULL)';
         EXECUTE IMMEDIATE 'ALTER TABLE POLL_VOTE MODIFY (USER_ID VARCHAR2(99) NOT NULL)';


### PR DESCRIPTION
## Summary

`polls_migrate_jpa()` (added in #289) deletes `POLL_OPTION` rows belonging to a poll whose `POLL_UUID` could not be resolved, but the `POLL_VOTE` cleanup only removed votes with a null `VOTE_OPTION`:

```sql
DELETE FROM POLL_VOTE WHERE VOTE_OPTION IS NULL;
```

Votes that still pointed at one of the `OPTION_ID`s just deleted from `POLL_OPTION` survived the migration as orphans, silently breaking referential integrity.

Confirmed against a real production database (2,610 polls): after running the current procedure, the standard post-migration check

```sql
SELECT COUNT(*) FROM POLL_VOTE v LEFT JOIN POLL_OPTION o ON v.VOTE_OPTION = o.OPTION_ID WHERE o.OPTION_ID IS NULL;
```

returned 1036 orphaned votes, while the equivalent checks for `POLL_POLL`/`POLL_OPTION` (malformed id, duplicate id, orphaned option) all returned 0.

## Fix

```sql
DELETE FROM POLL_VOTE
WHERE VOTE_OPTION IS NULL
   OR VOTE_OPTION NOT IN (SELECT OPTION_ID FROM POLL_OPTION);
```

Applied to both `sakai_26_mysql_conversion.sql` and `sakai_26_oracle_conversion.sql`, matching the pattern already used in #289 for the `POLL_UUID` self-heal and `OPTION_ORDER` default fixes.

## Test plan

- [x] Verified the bug is reproducible against real production data: 1036 orphaned votes remained after running the unmodified procedure.
- [x] Verified the fix removes exactly those orphaned rows and the post-migration orphan check returns 0, with no other row counts affected.
- [ ] Needs review from someone who can also validate the Oracle variant end-to-end (only validated the MySQL path directly; the Oracle `EXECUTE IMMEDIATE` change mirrors it 1:1).

Related: SAK-52811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll data migration by removing votes with missing or invalid options.
  * Prevented orphaned vote records and migration failures when enforcing required poll option values.
  * Applied the fix consistently for both MySQL and Oracle conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->